### PR TITLE
feat: displays estimated cost in ETH. Modal size auto scales

### DIFF
--- a/frontend/vite-react/src/components/TransactionConfirmationModal.tsx
+++ b/frontend/vite-react/src/components/TransactionConfirmationModal.tsx
@@ -57,7 +57,6 @@ const TransactionConfirmationModal = () => {
     if (transactionData) {
       setEthCost(calculateEthCost(transactionData).slice(1, 11))
     }
-    console.log(transactionData)
   }, [transactionData])
 
   // On transaction confirmed


### PR DESCRIPTION
- Auto sizes confirmation modal
- Displays estimated ETH cost for transaction
![bilde](https://github.com/user-attachments/assets/64c45a10-62da-4beb-9b61-38e14bbf688f)

Reset game used as an example

Closes #61 